### PR TITLE
Upgrade gson from 2.8.6 to 2.8.7

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -10,7 +10,7 @@ plugin.org.danilopianini.publish-on-central=0.2.3
 
 plugin.org.jlleitschuh.gradle.ktlint=9.0.0
 
-version.com.google.code.gson..gson=2.8.6
+version.com.google.code.gson..gson=2.8.7
 
 version.javax.annotation..jsr250-api=1.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.