### PR TITLE
Upgrade publish-on-central from 0.2.3 to 0.5.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,8 +33,8 @@ tasks.withType<Test> {
 
 group = "org.danilopianini"
 publishOnCentral {
-    projectDescription.set("Extra goodies for Gson, available on Google's Github repository, made available on Central")
-    projectLongName.set("Gson Extras")
+    projectDescription = "Extra goodies for Gson, available on Google's Github repository, made available on Central"
+    projectLongName = "Gson Extras"
 }
 
 publishing {

--- a/versions.properties
+++ b/versions.properties
@@ -11,7 +11,7 @@ plugin.io.gitlab.arturbosch.detekt=version.detekt
 
 plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.2
 
-plugin.org.danilopianini.publish-on-central=0.2.3
+plugin.org.danilopianini.publish-on-central=0.5.0
 
 plugin.org.jlleitschuh.gradle.ktlint=9.1.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.