### PR TITLE
Upgrade git-sensitive-semantic-versioning from 0.2.2 to 0.3.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,10 +13,6 @@ repositories {
     mavenCentral()
 }
 
-gitSemVer {
-    version = computeGitSemVer()
-}
-
 dependencies {
     api("com.google.code.gson:gson:_")
     implementation("javax.annotation:jsr250-api:_")

--- a/versions.properties
+++ b/versions.properties
@@ -9,7 +9,7 @@
 
 plugin.io.gitlab.arturbosch.detekt=version.detekt
 
-plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.2
+plugin.org.danilopianini.git-sensitive-semantic-versioning=0.3.0
 
 plugin.org.danilopianini.publish-on-central=0.5.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.