### PR TITLE
Upgrade gson from 2.8.7 to 2.8.8

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -15,7 +15,7 @@ plugin.org.danilopianini.publish-on-central=0.5.0
 
 plugin.org.jlleitschuh.gradle.ktlint=10.1.0
 
-version.com.google.code.gson..gson=2.8.7
+version.com.google.code.gson..gson=2.8.8
 
 version.detekt=1.18.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.