### PR TITLE
Upgrade detekt from 1.18.0 to 1.18.1

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -17,7 +17,7 @@ plugin.org.jlleitschuh.gradle.ktlint=10.1.0
 
 version.com.google.code.gson..gson=2.8.8
 
-version.detekt=1.18.0
+version.detekt=1.18.1
 
 version.javax.annotation..jsr250-api=1.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.